### PR TITLE
chore: allow murmurhash3 install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,8 @@
     "typedoc": "^0.28.20",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"
+  },
+  "allowScripts": {
+    "murmurhash3": true
   }
 }


### PR DESCRIPTION
### Motivation
- Allow the `murmurhash3` package install script to run without pinning an exact package version in the approval policy so future minor/patch updates don’t require re-approval.

### Description
- Add a name-only `allowScripts` entry in `package.json` with `"murmurhash3": true` and regenerate the lockfile with `npm install --package-lock-only` (npm reported the lockfile was already up to date, so no lockfile changes were produced).

### Testing
- Ran `npm install --package-lock-only` which completed successfully, and ran `npm test -- --run` (Vitest) which executed 38 tests and all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a504e4f4c508333b234e189caba12b7)